### PR TITLE
Set os.distro to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir $CONAN_USER_HOME && \
 
 RUN git clone http://github.com/ess-dmsc/conan-configuration.git && \
     cd conan-configuration && \
-    git checkout 5b1a947b11852a2022e8b81755a731ca4b25cdcd && \
+    git checkout 960eb876f6462f5d19008bf1a16badabeaf9949f && \
     cd .. && \
     conan config install conan-configuration && \
     rm -rf conan-configuration

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
   disableConcurrentBuilds(abortPrevious: true)
 ])
 
-imageVersion = '4.0.0'
+imageVersion = '5.0.0'
 
 imageName = "dockerregistry.esss.dk/ecdc_group/build-node-images/debian11-build-node:${imageVersion}"
 

--- a/files/default_profile
+++ b/files/default_profile
@@ -1,6 +1,7 @@
 [settings]
 os=Linux
 os_build=Linux
+os.distro=debian
 arch=x86_64
 arch_build=x86_64
 compiler=gcc


### PR DESCRIPTION
This is done to prevent binary packages from being downloaded when they don't match the profile; added because of glibc incompatibilities.